### PR TITLE
update poker-dvs notebook to comply with latest tonic 0.3.9 when creating sparse tensors

### DIFF
--- a/poker-dvs_classifier.ipynb
+++ b/poker-dvs_classifier.ipynb
@@ -327,7 +327,8 @@
     "\n",
     "example_events, target = trainset[10]\n",
     "\n",
-    "example_input = example_events.to_dense().unsqueeze(1).unsqueeze(1)"
+    "example_input = example_events.to_dense().unsqueeze(1) # the unsqueeze just signifies a batch size of 1\n",
+    "example_input.shape"
    ]
   },
   {
@@ -462,8 +463,7 @@
     "    losses = []\n",
     "\n",
     "    for (data, target) in tqdm(train_loader, leave=False):\n",
-    "#         import ipdb; ipdb.set_trace()\n",
-    "        data, target = data.to(device).to_dense().permute([1,0,2,3]).unsqueeze(2), torch.LongTensor(target).to(device)\n",
+    "        data, target = data.to(device).to_dense().permute([1,0,2,3,4]), torch.LongTensor(target).to(device)\n",
     "        optimizer.zero_grad()\n",
     "        output = model(data)\n",
     "        loss = torch.nn.functional.nll_loss(output, target)\n",
@@ -498,7 +498,7 @@
     "    correct = 0\n",
     "    with torch.no_grad():\n",
     "        for data, target in test_loader:\n",
-    "            data, target = data.to(device).to_dense().permute([1,0,2,3]).unsqueeze(2), torch.LongTensor(target).to(device)\n",
+    "            data, target = data.to(device).to_dense().permute([1,0,2,3,4]), torch.LongTensor(target).to(device)\n",
     "            output = model(data)\n",
     "            test_loss += torch.nn.functional.nll_loss(\n",
     "                output, target, reduction=\"sum\"\n",


### PR DESCRIPTION
Hello, this is but a fix to comply with tonic v0.3.9. The sparse tensor transformation now includes a channel dimension depending on the number of polarities. When collating batches however, the time and batch dimension still have to be switched. 